### PR TITLE
Encode strings that look like hexcodes with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0 (2020-04-05)
+
+- Ensure that we escape the first underscore character in plaintext strings that match the format for Excel escape sequences. 
+
 ## 2.4.0 (2020-06-27)
 
 - Allow writing worksheets without a block using add\_worksheet (#42, #45)

--- a/lib/xlsxtream/version.rb
+++ b/lib/xlsxtream/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Xlsxtream
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/lib/xlsxtream/xml.rb
+++ b/lib/xlsxtream/xml.rb
@@ -40,6 +40,8 @@ module Xlsxtream
       end
 
       # Add underscore to strings that merely look like hex values, preventing manipulation into invalid UTF8
+      # Per Microsoft Open Specifications for Excel:
+      # Underscore (0x005f): This character shall be escaped only when used to escape the first underscore character in the format _xHHHH_.
       def encode_underscores_using_x005f(string)
         string.gsub(HEX_ESCAPE_REGEXP) do |match|
           match.sub("_", XML_ESCAPE_UNDERSCORE)

--- a/lib/xlsxtream/xml.rb
+++ b/lib/xlsxtream/xml.rb
@@ -8,6 +8,9 @@ module Xlsxtream
       '>' => '&gt;',
     }.freeze
 
+    HEX_ESCAPE_REGEXP = /_x[0-9A-Fa-f]{4}_/
+    XML_ESCAPE_UNDERSCORE = '_x005f_'
+
     XML_DECLARATION = %'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n'.freeze
 
     WS_AROUND_TAGS = /(?<=>)\s+|\s+(?=<)/.freeze
@@ -36,8 +39,16 @@ module Xlsxtream
         string.gsub(UNSAFE_ATTR_CHARS, XML_ESCAPES)
       end
 
+      # Add underscore to strings that merely look like hex values, preventing manipulation into invalid UTF8
+      def encode_underscores_using_x005f(string)
+        string.gsub(HEX_ESCAPE_REGEXP) do |match|
+          match.sub("_", XML_ESCAPE_UNDERSCORE)
+        end
+      end
+
       def escape_value(string)
-        string.gsub(UNSAFE_VALUE_CHARS, XML_ESCAPES).gsub(INVALID_XML10_CHARS, &ESCAPE_CHAR)
+        excel_safe_string = encode_underscores_using_x005f(string)
+        excel_safe_string.gsub(UNSAFE_VALUE_CHARS, XML_ESCAPES).gsub(INVALID_XML10_CHARS, &ESCAPE_CHAR)
       end
 
     end

--- a/lib/xlsxtream/xml.rb
+++ b/lib/xlsxtream/xml.rb
@@ -39,17 +39,18 @@ module Xlsxtream
         string.gsub(UNSAFE_ATTR_CHARS, XML_ESCAPES)
       end
 
-      # Add underscore to strings that merely look like hex values, preventing manipulation into invalid UTF8
-      # Per Microsoft Open Specifications for Excel:
+      # Ensure that we escape the first underscore character in plaintext strings that match the format for Excel escape sequences.
+      # This ensures that these strings are displayed as plaintext and not incorrectly parsed as escape sequences by Excel
+      # Per Microsoft Open Specifications for Excel: https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/d34ae755-c53f-4a44-a363-c6dd3ee018a4
       # Underscore (0x005f): This character shall be escaped only when used to escape the first underscore character in the format _xHHHH_.
-      def encode_underscores_using_x005f(string)
+      def escape_strings_that_match_excel_escape_sequence(string)
         string.gsub(HEX_ESCAPE_REGEXP) do |match|
           match.sub("_", XML_ESCAPE_UNDERSCORE)
         end
       end
 
       def escape_value(string)
-        excel_safe_string = encode_underscores_using_x005f(string)
+        excel_safe_string = escape_strings_that_match_excel_escape_sequence(string)
         excel_safe_string.gsub(UNSAFE_VALUE_CHARS, XML_ESCAPES).gsub(INVALID_XML10_CHARS, &ESCAPE_CHAR)
       end
 

--- a/test/xlsxtream/xml_test.rb
+++ b/test/xlsxtream/xml_test.rb
@@ -42,5 +42,22 @@ module Xlsxtream
       expected = safe_value
       assert_equal expected, XML.escape_value(safe_value)
     end
+
+    def test_encode_underscores_using_x005f
+      unsafe_value = "_xDcc2_"
+      safe_value = "_x005f_xDcc2_"
+      assert_equal safe_value, XML.escape_value(unsafe_value)
+    end
+
+    def test_encode_underscores_using_x005f_multiple_occurrences
+      unsafe_value = "_xDcc2_aa_x3d12_bb_xDea3_cc_xDaa5_"
+      safe_value = "_x005f_xDcc2_aa_x005f_x3d12_bb_x005f_xDea3_cc_x005f_xDaa5_"
+      assert_equal safe_value, XML.escape_value(unsafe_value)
+    end
+
+    def test_not_escaping_regular_underscores
+      safe_value = "this_test_does_not_replace_underscores_xDcc2"
+      assert_equal safe_value, XML.escape_value(safe_value)
+    end
   end
 end


### PR DESCRIPTION
Fork xlsxtream code to properly respect hex-similar strings by replacing _ via _x005f_

Implements Underscore escape per Microsoft Excel spec:
> Underscore (0x005f): This character shall be escaped only when used to escape the first underscore character in the format _xHHHH_.